### PR TITLE
Fix leftover ng-valid class from bound control

### DIFF
--- a/src/international-phone-number.coffee
+++ b/src/international-phone-number.coffee
@@ -14,7 +14,7 @@ angular.module("internationalPhoneNumber", []).directive 'internationalPhoneNumb
       ctrl.$setViewValue element.val()
 
     handleWhatsSupposedToBeAnArray = (value) ->
-      if typeof(value) == "object"
+      if value instanceof Array
         value
       else
         value.toString().replace(/[ ]/g, '').split(',')
@@ -53,7 +53,9 @@ angular.module("internationalPhoneNumber", []).directive 'internationalPhoneNumb
 
     ctrl.$parsers.push (value) ->
       if value
-        ctrl.$setValidity 'international-phone-number', element.intlTelInput("isValidNumber")
+        validity = element.intlTelInput("isValidNumber")
+        ctrl.$setValidity 'international-phone-number', validity
+        ctrl.$setValidity '', validity
       else
         value = ''
         delete ctrl.$error['international-phone-number']


### PR DESCRIPTION
Currently, a valid phone number input is left with classes `ng-scope ng-dirty ng-valid-international-phone-number ng-valid`.

This change syncs the `ng-valid` class with `ng-valid-international-phone-number`, also making the latter redundant.