### PR TITLE
skip-util-script-download attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,6 @@ Feel free to mix options together:
 <input type="text" international-phone-number only-countries="pl, de, en, es" default-country="pl" preferred-countries="pl, de" ng-model="phone">
 ```
 
-
+Options
+---
+By default the directive lazy loads utils.js. If you want to load this yourself, use the `skip-util-script-download` attribute.

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
   "license": "MIT",
   "dependencies": {
     "angular": "~1.2.9",
-    "intl-tel-input": "~3.6.5"
+    "intl-tel-input": "~5.1.0"
   }
 }

--- a/src/international-phone-number.coffee
+++ b/src/international-phone-number.coffee
@@ -8,6 +8,7 @@ angular.module("internationalPhoneNumber", []).directive 'internationalPhoneNumb
   require: '^ngModel'
   scope: {
     ngModel: '='
+    defaultCountry: '@'
   }
 
   link: (scope, element, attrs, ctrl) ->
@@ -46,15 +47,20 @@ angular.module("internationalPhoneNumber", []).directive 'internationalPhoneNumb
 
     # Wait for ngModel to be set
     watchOnce = scope.$watch('ngModel', (newValue) ->
-      if newValue != null and newValue != undefined and newValue != ''
-        element.val newValue
+      # Wait to see if other scope variables were set at the same time
+      scope.$$postDigest ->
+        options.defaultCountry = scope.defaultCountry
         
-      element.intlTelInput(options)
+        if newValue != null and newValue != undefined and newValue != ''
+          element.val newValue
+        
+        element.intlTelInput(options)
 
-      unless options.utilsScript
-        element.intlTelInput('loadUtils', '/bower_components/intl-tel-input/lib/libphonenumber/build/utils.js')
+        unless options.utilsScript
+          element.intlTelInput('loadUtils', '/bower_components/intl-tel-input/lib/libphonenumber/build/utils.js')
       
-      watchOnce()
+        watchOnce()
+
     )
 
 

--- a/src/international-phone-number.coffee
+++ b/src/international-phone-number.coffee
@@ -6,7 +6,9 @@ angular.module("internationalPhoneNumber", []).directive 'internationalPhoneNumb
 
   restrict:   'A'
   require: '^ngModel'
-  scope: true
+  scope: {
+    ngModel: '='
+  }
 
   link: (scope, element, attrs, ctrl) ->
 
@@ -42,10 +44,20 @@ angular.module("internationalPhoneNumber", []).directive 'internationalPhoneNumb
       else
         options[key] = option
 
-    element.intlTelInput(options)
+    # Wait for ngModel to be set
+    watchOnce = scope.$watch('ngModel', (newValue) ->
+      if newValue != null and newValue != undefined and newValue != ''
+        element.val newValue
+        
+      element.intlTelInput(options)
 
-    unless options.utilsScript
-      element.intlTelInput('loadUtils', '/bower_components/intl-tel-input/lib/libphonenumber/build/utils.js')
+      unless options.utilsScript
+        element.intlTelInput('loadUtils', '/bower_components/intl-tel-input/lib/libphonenumber/build/utils.js')
+      
+      watchOnce()
+    )
+
+
 
     ctrl.$parsers.push (value) ->
       return value if !value

--- a/src/international-phone-number.coffee
+++ b/src/international-phone-number.coffee
@@ -56,7 +56,7 @@ angular.module("internationalPhoneNumber", []).directive 'internationalPhoneNumb
         
         element.intlTelInput(options)
 
-        unless options.utilsScript
+        unless attrs.skipUtilScriptDownload != undefined || options.utilsScript
           element.intlTelInput('loadUtils', '/bower_components/intl-tel-input/lib/libphonenumber/build/utils.js')
       
         watchOnce()


### PR DESCRIPTION
This pull request depends on #12. Only the last commit (014cbe6)  is relevant.

Lazy loading `/bower_components/intl-tel-input/lib/libphonenumber/build/utils.js` can cause problems when files are in a different place (e.g. if you concatenate and minify all javascript files). The way jQuery loads it - using eval() - also causes problems if an HTTP header like `content-security-policy: script-src 'self'`is set.

The `skip-util-script-download` prevents utils.js from being loaded so that you can load it in other place.