### PR TITLE
Avoid inconsistent validity due to deleting from $error

### DIFF
--- a/src/international-phone-number.coffee
+++ b/src/international-phone-number.coffee
@@ -76,7 +76,7 @@ angular.module("internationalPhoneNumber", []).directive 'internationalPhoneNumb
         ctrl.$setValidity '', validity
       else
         value = ''
-        delete ctrl.$error['international-phone-number']
+        ctrl.$setValidity 'international-phone-number', true
       value
 
     element.on 'blur keyup change', (event) ->


### PR DESCRIPTION
We noticed that in some cases after clearing the field to type a new number the `ng-invalid` class stuck around despite being `ng-valid-international-phone-number` with no other validity issues. This fixes what may be due to an inconsistency in ngModelController after deleting the key from `$error`.

We experienced the issue in the following use cases. Starting with a blank US phone number +1 and trying to add a Dutch phone number +31 6 22222222
* Select all text, paste or type 31622222222
* Select all text, type +, paste or type 31622222222
* Focus field, delete the 1 leaving just +, paste or type 31622222222
* Type + (without first removing +1), paste or type 31622222222

All four approaches result in a blank value (even when the field has just a + sign the parsed value is blank) which passes through this line of code that deletes the validity flag. My assumption is that doing so rather than using `$setValidity('international-phone-number', true)` puts the model controller into an inconsistent state. When valid, the `$error` object should contain `{ 'international-phone-number': false }` and when invalid, `{ 'international-phone-number': true }`.