### PR TITLE
$setValidity should not be used with a blank error key.

### DIFF
--- a/src/international-phone-number.coffee
+++ b/src/international-phone-number.coffee
@@ -73,7 +73,6 @@ angular.module("internationalPhoneNumber", []).directive 'internationalPhoneNumb
       if value
         validity = element.intlTelInput("isValidNumber")
         ctrl.$setValidity 'international-phone-number', validity
-        ctrl.$setValidity '', validity
       else
         value = ''
         delete ctrl.$error['international-phone-number']


### PR DESCRIPTION
This can unintentionally make the field required; if the text field is cleared while displaying an invalid phone number, the '' error key will remain invalid.

To test:

1. Begin with a non-required international-phone-number field
2. Type an invalid phone number such as +1 555 555 5555
3. Delete the phone number leaving a blank field (or just the + prompt)

The field will have a validation error, `$error: {"international-phone-number":false,"":true}` because the blank validation key is still invalid. I believe that b0a4feaee8 where this blank error key was introduced was attempting to resolve the problem fixed in #15.