### PR TITLE
Fixed invalid bower dependency syntax.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   "author": "Marek Pietrucha (http://enginearch.com)",
   "license": "MIT",
   "dependencies": {
-    "angular": "=>1.2.0",
+    "angular": ">=1.2.0",
     "intl-tel-input": "~5.1.0"
   }
 }


### PR DESCRIPTION
Was using => rather than >= which on install caused bower to spew out a spectacularly long (70kb) list of tags that *are* available for angular. `=>1.2.0` made it look for a tag called ">1.2.0" which does not exist.