### PR TITLE
Adds an angular $formatter to handle model value updates.

### DIFF
--- a/src/international-phone-number.coffee
+++ b/src/international-phone-number.coffee
@@ -64,6 +64,9 @@ angular.module("internationalPhoneNumber", []).directive 'internationalPhoneNumb
     )
 
 
+    ctrl.$formatters.push (value) ->
+      element.intlTelInput 'setNumber', value
+      return element.val
 
     ctrl.$parsers.push (value) ->
       return value if !value


### PR DESCRIPTION
Fixes improper formatting of numbers when fields load with an existing ng-model value. The directive was not observing programmatic changes to the model value, which apparently in my case happen momentarily after the field is created. A function was pushed to the model controller's `$formatters` to reformat that initial value to a proper string with correct country flag.

This may not be the best way to handle data formatting since it has to change the value in the field in order to return the new value to put in the field, but intl-tel-input does not offer a static method to format a number outside of a field.