### PR TITLE
Updated minimal required Angular version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "author": "Marek Pietrucha (http://enginearch.com)",
   "license": "MIT",
   "dependencies": {
-    "angular": ">1.2.0",
+    "angular": ">1.3.0",
     "intl-tel-input": "~5.1.0"
   }
 }


### PR DESCRIPTION
Angular >1.3 is required (ngModel.$validators introduced for the first time)