### PR TITLE
fix redundant comments when used with ngIf

### DIFF
--- a/src/international-phone-number.coffee
+++ b/src/international-phone-number.coffee
@@ -104,6 +104,10 @@ angular.module("internationalPhoneNumber", []).directive 'internationalPhoneNumb
     element.on 'blur keyup change', (event) ->
       scope.$apply read
 
+    scope.$on '$destroy', () ->
+      element.hide()
+      element.parent().remove()
+
     element.on '$destroy', () ->
       element.intlTelInput('destroy');
       element.off 'blur keyup change'


### PR DESCRIPTION
remove parent elements added by jquery plugin, so ng-if can get the correct element to remove from dom