### PR TITLE
Add skip utils to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,18 +28,19 @@ Same as in source project (https://github.com/Bluefieldscom/intl-tel-input)
 
 Sneak preview:
 ```coffeescript
-    allowExtensions:    false
-    autoFormat:         true
-    autoHideDialCode:   true
-    autoPlaceholder:    true
-    customPlaceholder:  null
-    defaultCountry:     ""
-    geoIpLookup:        null
-    nationalMode:       true
-    numberType:         "MOBILE"
-    onlyCountries:      undefined
-    preferredCountries: ['us', 'gb']
-    utilsScript:        ""
+    allowExtensions:        false
+    autoFormat:             true
+    autoHideDialCode:       true
+    autoPlaceholder:        true
+    customPlaceholder:      null
+    defaultCountry:         ""
+    geoIpLookup:            null
+    nationalMode:           true
+    numberType:             "MOBILE"
+    onlyCountries:          undefined
+    preferredCountries:     ['us', 'gb']
+    skipUtilScriptDownload: false
+    utilsScript:            ""
 ```
 
 Global configuration (in angulars config phase)
@@ -85,7 +86,7 @@ Feel free to mix options together:
 
 Options
 ---
-By default the directive lazy loads utils.js. If you want to load this yourself, use the `skip-util-script-download` attribute.
+By default the directive lazy loads utils.js. If you want to load this yourself, use the `skip-util-script-download` attribute or set the ipnConfig.skipUtilScriptDownload to true.
 
 
 License

--- a/src/international-phone-number.coffee
+++ b/src/international-phone-number.coffee
@@ -5,18 +5,19 @@
 angular.module("internationalPhoneNumber", [])
 
 .constant 'ipnConfig', {
-    allowExtensions:    false
-    autoFormat:         true
-    autoHideDialCode:   true
-    autoPlaceholder:    true
-    customPlaceholder:  null
-    defaultCountry:     ""
-    geoIpLookup:        null
-    nationalMode:       true
-    numberType:         "MOBILE"
-    onlyCountries:      undefined
-    preferredCountries: ['us', 'gb']
-    utilsScript:        ""
+    allowExtensions:        false
+    autoFormat:             true
+    autoHideDialCode:       true
+    autoPlaceholder:        true
+    customPlaceholder:      null
+    defaultCountry:         ""
+    geoIpLookup:            null
+    nationalMode:           true
+    numberType:             "MOBILE"
+    onlyCountries:          undefined
+    preferredCountries:     ['us', 'gb']
+    skipUtilScriptDownload: false
+    utilsScript:            ""
   }
 
 .directive 'internationalPhoneNumber', ['$timeout', 'ipnConfig', ($timeout, ipnConfig) ->
@@ -73,7 +74,7 @@ angular.module("internationalPhoneNumber", [])
 
         element.intlTelInput(options)
 
-        unless attrs.skipUtilScriptDownload != undefined || options.utilsScript
+        unless options.skipUtilScriptDownload || attrs.skipUtilScriptDownload != undefined || options.utilsScript
           element.intlTelInput('loadUtils', '/bower_components/intl-tel-input/lib/libphonenumber/build/utils.js')
 
         watchOnce()


### PR DESCRIPTION
Adds an option to ipnConfig to allow for global skip-util-script-download.

I include it globally in my app and do not want to muddy up all my tel input elements with the same attribute over and over