### PR TITLE
Update NPM package to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "international-phone-number",
-  "version": "0.0.11",
+  "version": "0.0.16",
   "description": "AngularJS directive for intl-tel-input jQuery plugin",
   "keywords": [
     "international",


### PR DESCRIPTION
[According to NPM][npm-ipn], the latest release of this software was version 0.0.11

The Bower configuration and Git tags both reflect the truth, however - that the most current version is 0.0.16.

Update the NPM configuration file so that the newer version of this directive is available on NPM.

[npm-ipn]: https://www.npmjs.com/package/international-phone-number